### PR TITLE
Add script to quick-add blog post about the last video

### DIFF
--- a/_script/download.py
+++ b/_script/download.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Download CodeRegation proposal from GitHub and convert to blogpost.
+
+Usage: see command line help.
+"""
+import requests
+import json
+import argparse
+import datetime
+import pathlib
+
+def last_wednesday():
+    today = datetime.date.today()
+    offset = (today.weekday() - 2) % 7
+    day = today - datetime.timedelta(days=offset)
+    return day.strftime('%Y-%m-%d')
+
+parser = argparse.ArgumentParser(description='Download CodeRegation proposal from GitHub and convert to blogpost.')
+parser.add_argument('--id', help='GitHub issue id', required=True)
+parser.add_argument('--date', help='Date of CodeRegation meeting. Default: last Wednesday.', default=last_wednesday())
+args = parser.parse_args()
+
+issue_id = args.id
+date = args.date
+
+response = requests.get(url=f'https://api.github.com/repos/balabit/coderegation/issues/{issue_id}')
+data = response.json()
+description = data['body']
+print(f'Preparing "{data["title"]}" at "{date}"')
+
+new_item = pathlib.Path(__file__).with_name('new_item.md')
+
+with new_item.open('w') as f:
+    f.write(f'date: {date}\n')
+    f.write(f'issue:  {issue_id}\n')
+    f.write(description)
+
+print('-----------------------------------------------------')
+print(new_item.read_text())

--- a/_script/quick-add.sh
+++ b/_script/quick-add.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+echo "Add last Coderegation video as blog post automatically."
+
+
+if [ -z "$1" ]; then
+    echo "ERROR: The first parameter must be the issue id in GitHub"
+    exit 1
+fi
+
+issue_id="$1"
+
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+echo
+echo "Downloading..."
+./download.py --id "$issue_id"
+
+echo
+echo "Converting..."
+./convert.py
+
+cd ..
+echo
+git status
+echo
+echo "Press ENTER to commit every post"
+read
+git add _posts
+git commit -sm "New video, closes #$issue_id"
+


### PR DESCRIPTION
Most of our video proposals are well-formatted, so instead of doing many parts manually, now we can just run

```
$ _script/quick-add.sh 94
```

to add the proposal with issue id #94 as the video of the latest event.
